### PR TITLE
Fix for divide by zero error

### DIFF
--- a/plag.py
+++ b/plag.py
@@ -22,7 +22,7 @@ def cosineSimilarity():
 	lowercaseQuery = inputQuery.lower()
 
 	queryWordList = re.sub("[^\w]", " ",lowercaseQuery).split()			#Replace punctuation by space and split
-	queryWordList = map(str, queryWordList)
+	# queryWordList = map(str, queryWordList)					#This was causing divide by zero error
 
 	for word in queryWordList:
 		if word not in universalSetOfUniqueWords:
@@ -34,7 +34,7 @@ def cosineSimilarity():
 	database1 = fd.read().lower()
 
 	databaseWordList = re.sub("[^\w]", " ",database1).split()	#Replace punctuation by space and split
-	databaseWordList = map(str, databaseWordList)
+	# databaseWordList = map(str, databaseWordList)			#And this also leads to divide by zero error
 
 	for word in databaseWordList:
 		if word not in universalSetOfUniqueWords:


### PR DESCRIPTION
remove the following statements from code ( I have commented them @ line no 25 and 37)
    queryWordList = map(str, queryWordList)

    databaseWordList = map(str, databaseWordList

its because map can be iterated only once and we are iterating them twice in this code (refer this https://stackoverflow.com/questions/36486950/python-calling-list-on-a-map-object-twice)
   for word in queryWordList:  and second time as
   for word2 in queryWordList:
same for databaseWordList

Hope this helps you and other who are using your code : )